### PR TITLE
Add the means to retrieve token file from disk as cache fallback (if not found on default cache)

### DIFF
--- a/marmalade-upload.el
+++ b/marmalade-upload.el
@@ -37,6 +37,19 @@
 This is the result of authentication.  If you have the token you
 don't need to re-authenticate.")
 
+(defvar marmalade/default-token-folder "~/.marmalade"
+  "Default folder to look for a token on disk.")
+
+(defvar marmalade/default-token-name   nil
+  "Default token name to search on disk.
+If set to nil, the token filename is the user's login.")
+
+(defun marmalade/compute-token-filepath (login)
+  "Compute the token's filepath from disk.
+If the default token name is not set, the LOGIN is used as the token filename."
+  (let ((token-filename (if marmalade/default-token-name marmalade/default-token-name login)))
+    (expand-file-name (format "%s/%s" marmalade/default-token-folder token-filename))))
+
 (defun marmalade/token-acquired (username token next)
   "Called by `marmalade/token-acquire'."
   (puthash username token marmalade/tokens)
@@ -77,11 +90,12 @@ If found returns it, otherwise, returns nil."
   (let ((token (gethash username marmalade/tokens)))
     (if token
         token
-      (let ((token-file (expand-file-name (format "~/.marmalade/%s" username))))
+      (let ((token-file (marmalade/compute-token-filepath username)))
         (when (file-exists-p token-file)
           (with-temp-buffer ;; return the token file's content
             (insert-file-contents token-file)
             (buffer-string)))))))
+
 (defun marmalade-upload (package-buffer username &optional password)
   "Upload a package to marmalade using `web'."
   (interactive

--- a/marmalade-upload.el
+++ b/marmalade-upload.el
@@ -68,7 +68,7 @@ don't need to re-authenticate.")
 ;;(defconst marmalade-url "http://localhost:8000/v1/packages"
 ;;  "The URL where we send packages.")
 
-(defun marmalade-upload/get-token (username)
+(defun marmalade/--get-token-from-cache (username)
   "Try and retrieve the USERNAME's token.
 First in the marmalade-upload's cache.
 If not found, this will try to locate a file ~/.marmalade/<username>.
@@ -96,8 +96,8 @@ If found returns it, otherwise, returns nil."
          ;;;  (get-buffer (read-buffer "package file buffer: " nil t))
          (find-file-noselect (read-file-name "package file: ") t t)))
     (let ((username (read-from-minibuffer "marmalade username: ")))
-      ;; Only need password if we don't have the token cached
-      (if (marmalade-upload/get-token username)
+      ;; Only need password if we don't have the token cached (or stored)
+      (if (marmalade/--get-token-from-cache username)
           (list username)
           (list username (read-passwd "marmalade password: "))))))
   (let ((uploader
@@ -114,7 +114,7 @@ If found returns it, otherwise, returns nil."
             :url marmalade-url
             :headers '(("Accept" . "application/json"))
             :data `(("name" . ,username)
-                    ("token" .  ,(marmalade-upload/get-token username))
+                    ("token" .  ,(marmalade/--get-token-from-cache username))
                     ("package" . ,package-buffer))
             :mime-type web-multipart-mimetype))))
     (if (equal password nil)

--- a/marmalade-upload.el
+++ b/marmalade-upload.el
@@ -68,7 +68,7 @@ don't need to re-authenticate.")
 ;;(defconst marmalade-url "http://localhost:8000/v1/packages"
 ;;  "The URL where we send packages.")
 
-(defun marmalade/--get-token-from-cache (username)
+(defun marmalade/get-token-from-cache (username)
   "Try and retrieve the USERNAME's token.
 First in the marmalade-upload's cache.
 If not found, this will try to locate a file ~/.marmalade/<username>.
@@ -97,7 +97,7 @@ If found returns it, otherwise, returns nil."
          (find-file-noselect (read-file-name "package file: ") t t)))
     (let ((username (read-from-minibuffer "marmalade username: ")))
       ;; Only need password if we don't have the token cached (or stored)
-      (if (marmalade/--get-token-from-cache username)
+      (if (marmalade/get-token-from-cache username)
           (list username)
           (list username (read-passwd "marmalade password: "))))))
   (let ((uploader
@@ -114,7 +114,7 @@ If found returns it, otherwise, returns nil."
             :url marmalade-url
             :headers '(("Accept" . "application/json"))
             :data `(("name" . ,username)
-                    ("token" .  ,(marmalade/--get-token-from-cache username))
+                    ("token" .  ,(marmalade/get-token-from-cache username))
                     ("package" . ,package-buffer))
             :mime-type web-multipart-mimetype))))
     (if (equal password nil)


### PR DESCRIPTION
Hello,

Just a proposal.

I used a script command before that did the upload.
It does not work at the moment.

But this package does.
There is a slight workflow difference with my own.
I load the token from disk.

This script just loaded the token file ~/.marmalade/token and provided
it to curl as an option.

For deploying my latest package, I tricked marmalade-upload `(puthash "ardumont"
my-token marmalade/tokens)`.

So I just extracted a function that retrieved the token.
If first tries as originally from the cache.
If nothing is found, try to load the `~/.marmalade/<username>` if the file exists.
If it does, it loads its content (which is assumed to be exactly the
token).
If nothing is found, returns nil.

This function is used at 2 positions:
- when computing the arguments to determine if the password is needed or not
- in the lambda when doing the actual upload request

As I do not know if you are interested at all, I did not:
- adapt the removal steps when the token is invalid (the token file could be removed?)
- nor update the cache with the token file's content (the token file's content can be poured into the cache?)

Cheers,
